### PR TITLE
Enhance semantic conventions for HTTP

### DIFF
--- a/specification/data-semantic-conventions.md
+++ b/specification/data-semantic-conventions.md
@@ -43,7 +43,7 @@ It is recommended to also use the `peer.*` attributes, especially `peer.ip*`.
 
 This span type represents an outbound HTTP request.
 
-For a HTTP client span, `SpanKind` MUST be `Client`.
+For an HTTP client span, `SpanKind` MUST be `Client`.
 
 `http.url` is required and represents the HTTP URL used to (initially) make this request.
 
@@ -51,7 +51,7 @@ For a HTTP client span, `SpanKind` MUST be `Client`.
 
 This span type represents an inbound HTTP request.
 
-For a HTTP server span, `SpanKind` MUST be `Server`.
+For an HTTP server span, `SpanKind` MUST be `Server`.
 
 Given an inbound request for a route (e.g. `"/users/:userID?"` the `name` attribute of the span SHOULD be set to this route. If the route does not include the application root path, it SHOULD be prepended to the span name.
 

--- a/specification/data-semantic-conventions.md
+++ b/specification/data-semantic-conventions.md
@@ -17,16 +17,13 @@ correlated and cross-analyzed.
 
 ## HTTP
 
-This span types represents HTTP requests. They can be used for http and https
+These span types represent HTTP requests. They can be used for http and https
 schemes and various HTTP versions like 1.1, 2 and SPDY.
 
 Given an [RFC 3986](https://tools.ietf.org/html/rfc3986) compliant URI of the form
 `scheme:[//host[:port]]path[?query][#fragment]`, the span name of the span SHOULD
-be set to to the URI path value.
-
-If a value that represents the identity of the request
-and has a lower cardinality than the URI path can be identified, this value MUST
-be used for the span name instead.
+be set to to the URI path value, unless another value that represents the identity
+of the request and has a lower cardinality can be identified.
 
 | Attribute name | Notes and examples                                           | Required? |
 | :------------- | :----------------------------------------------------------- | --------- |

--- a/specification/data-semantic-conventions.md
+++ b/specification/data-semantic-conventions.md
@@ -14,49 +14,106 @@ This way, the operator will not need to learn specifics of a language and
 telemetry collected from multi-language micro-service can still be easily
 correlated and cross-analyzed.
 
-## HTTP client
+
+## HTTP
+
+This span types represents HTTP requests. They can be used for http and https
+schemes and various HTTP versions like 1.1, 2 and SPDY.
+
+Given an [RFC 3986](https://tools.ietf.org/html/rfc3986) compliant URI of the form
+`scheme:[//authority]path[?query][#fragment]`, the span name of the span SHOULD
+be set to to the URI path value.
+
+If a value that represents the identity of the request
+and has a lower cardinality than the URI path can be identified, this value MUST
+be used for the span name instead.
+
+| Attribute name | Notes and examples                                           | Required? |
+| :------------- | :----------------------------------------------------------- | --------- |
+| `component`    | Denotes the type of the span and needs to be `"http"`. | Yes |
+| `http.method` | HTTP request method. E.g. `"GET"`. | Yes |
+| `http.url` | Full HTTP request URL in the form `scheme://host:port/path?query#fragment`. Usually the fragment is not transmitted over HTTP, but if it is known, it should be included nevertheless. | Defined later. |
+| `http.status_code` | [HTTP response status code][]. E.g. `200` (integer) | No |
+| `http.status_text` | [HTTP reason phrase][]. E.g. `"OK"` | No |
+| `http.flavor` | Kind of HTTP protocol used: `"1.0"`, `"1.1"`, `"2"`, `"SPDY"` or `"QUIC"`. |  If not TCP-based (`QUIC`). |
+
+[HTTP response status code]: https://tools.ietf.org/html/rfc7231#section-6
+[HTTP reason phrase]: https://tools.ietf.org/html/rfc7230#section-3.1.2
+
+It is recommended to also use the general [network attributes][], especially `peer.ip`. If `sock.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
+
+### HTTP client
 
 This span type represents an outbound HTTP request.
 
 For a HTTP client span, `SpanKind` MUST be `Client`.
 
-Given an [RFC 3986](https://www.ietf.org/rfc/rfc3986.txt) compliant URI of the form
-`scheme:[//authority]path[?query][#fragment]`, the span name of the span SHOULD
-be set to to the URI path value.
+`http.url` is required and represents the HTTP URL used to (initially) make this request.
 
-If a framework can identify a value that represents the identity of the request
-and has a lower cardinality than the URI path, this value MUST be used for the span name instead.
-
-| Attribute name | Notes and examples                                           | Required? |
-| :------------- | :----------------------------------------------------------- | --------- |
-| `component`    | Denotes the type of the span and needs to be `"http"`. | Yes |
-| `http.method` | HTTP request method. E.g. `"GET"`. | Yes |
-| `http.url` | HTTP URL of this request, represented as `scheme://host:port/path?query#fragment` E.g. `"https://example.com:779/path/12314/?q=ddds#123"`. | Yes |
-| `http.status_code` | [HTTP response status code](https://tools.ietf.org/html/rfc7231). E.g. `200` (integer) | No |
-| `http.status_text` | [HTTP reason phrase](https://www.ietf.org/rfc/rfc2616.txt). E.g. `"OK"` | No |
-
-## HTTP server
+### HTTP server
 
 This span type represents an inbound HTTP request.
 
 For a HTTP server span, `SpanKind` MUST be `Server`.
 
-Given an inbound request for a route (e.g. `"/users/:userID?"` the `name`
-attribute of the span SHOULD be set to this route.
+Given an inbound request for a route (e.g. `"/users/:userID?"` the `name` attribute of the span SHOULD be set to this route. If the route does not include the application root path, it SHOULD be prepended to the span name.
 
-If the route can not be determined, the `name` attribute MUST be set to the [RFC 3986 URI](https://www.ietf.org/rfc/rfc3986.txt) path value.
-
-If a framework can identify a value that represents the identity of the request
-and has a lower cardinality than the URI path or route, this value MUST be used for the span name instead.
+If the route cannot be determined, the `name` attribute MUST be set as defined in the general semantic conventions for HTTP.
 
 | Attribute name | Notes and examples                                           | Required? |
 | :------------- | :----------------------------------------------------------- | --------- |
-| `component`    | Denotes the type of the span and needs to be `"http"`. | Yes |
-| `http.method` | HTTP request method. E.g. `"GET"`. | Yes |
-| `http.url` | HTTP URL of this request, represented as `scheme://host:port/path?query#fragment` E.g. `"https://example.com:779/path/12314/?q=ddds#123"`. | Yes |
-| `http.route` | The matched route. E.g. `"/users/:userID?"`. | No |
-| `http.status_code` | [HTTP response status code](https://tools.ietf.org/html/rfc7231). E.g. `200` (integer) | No |
-| `http.status_text` | [HTTP reason phrase](https://www.ietf.org/rfc/rfc2616.txt). E.g. `"OK"` | No |
+| `http.target` | The full request target as passed in a [HTTP request line][] or equivalent, e.g. `/path/12314/?q=ddds#123"`. | [1] |
+| `http.host` | The value of the [HTTP host header][]. Note that this might be empty or not present. | [1] |
+| `http.scheme` | The URI scheme identifying the used protocol: `"http"` or `"https"` | [1] |
+| `http.server_name` | The server name (not including port). This should be obtained via configuration. If no such configuration can be obtained, this attribute MUST NOT be set (`host.name` from the [network attributes][] should be used instead). | [1] |
+| `http.route` | The matched route (path template). E.g. `"/users/:userID?"`. | No |
+| `http.app` | An identifier for the whole HTTP application. E.g. Flask app name, `spring.application.name`, etc. | No |
+| `http.app_root` |The path prefix of the URL that identifies this `http.app`. Also known as "context root". If multiple roots exist, the one that was matched for this request should be used. | No |
+| `http.client_ip` | The IP address of the original client behind all proxies, if known (e.g. from [X-Forwarded-For][]). For syntax, see `peer.ip`. | No |
+
+[HTTP request line]: https://tools.ietf.org/html/rfc7230#section-3.1.1
+[HTTP host header]: https://tools.ietf.org/html/rfc7230#section-5.4
+[X-Forwarded-For]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
+
+**[1]**: `http.url` is usually not readily available on the server side but would have to be assembled in a cumbersome and sometimes lossy process from other information (see e.g. <https://github.com/open-telemetry/opentelemetry-python/pull/148>).
+It is thus preferred to supply the raw data that *is* available.
+Namely, one of the following sets is required (in order of preference, all strings must be non-empty):
+
+* `http.scheme`, `http.host`, `http.target`
+* `http.scheme`, `http.server_name`, `host.port`, `http.target`
+* `http.scheme`, `host.name`, `host.port`, `http.target`
+* `http.url`
+
+Of course, more than the required attributes can be supplied, but this is recommended only if they cannot be inferred from the sent ones. For example, `http.server_name` might be valuable in a scenario where multiple "virtual" hosts are served by a server under the same IP.
+
+It is recommended to also use the `code.ns` and `code.func` [code attributes][] to name the logical handler method (`code.ns` + `code.func` will have a lower cardinality than `http.route`).
+
+As an example, if a browser request for `https://example.com:8080/webshop/articles/4?s=1` is invoked, we may have:
+
+Span name: `/webshop/articles/:article_id` (`app_root` + `route`).
+
+|   Attribute name   |                                       Value                                       |
+| :----------------- | :-------------------------------------------------------------------------------- |
+| `component`        | `"http"`                                                                          |
+| `http.method`      | `"GET"`                                                                           |
+| `http.url`         | `"https://example.com:8080/webshop/articles/4?s=1"` (or not set)                  |
+| `http.target`      | `"/webshop/articles/4?s=1"`                                                       |
+| `http.host`        | `"example.com:8080"`                                                              |
+| `http.server_name` | `"example.org"` (in that case, the canonical server name does not match the host) |
+| `host.port`        | `8080`                                                                            |
+| `http.scheme`      | `"https"`                                                                         |
+| `http.route`       | `"/articles/:article_id"` (note that the `app_root` part is missing in this case) |
+| `http.status_code` | `200`                                                                             |
+| `http.status_text` | `"OK"`                                                                            |
+| `http.app`         | E.g., `"My cool WebShop"` or `"com.example.webshop"`                              |
+| `http.app_root`    | `"/webshop"`                                                                      |
+| `http.client_ip`   | `"192.0.2.4"`                                                                     |
+| `peer.ip`          | `"192.0.2.5"` (the client goes through a proxy)                                   |
+| `code.ns`          | `"com.example.webshop.ArticleService"`                                            |
+| `code.func`        | `"showArticleDetails"`                                                            |
+
+Note that a naive implementation might set `code.ns` = `com.example.mywebframework.HttpDispatcherServlet` and `code.func` = `service`.
+If possible, this should be avoided and the logically responsible more specific handler method should be used, even if the span is actually started and ended in the web framework (integration).
 
 ## Databases client calls
 

--- a/specification/data-semantic-conventions.md
+++ b/specification/data-semantic-conventions.md
@@ -62,11 +62,13 @@ If the route cannot be determined, the `name` attribute MUST be set as defined i
 | `http.target` | The full request target as passed in a [HTTP request line][] or equivalent, e.g. `/path/12314/?q=ddds#123"`. | [1] |
 | `http.host` | The value of the [HTTP host header][]. Note that this might be empty or not present. | [1] |
 | `http.scheme` | The URI scheme identifying the used protocol: `"http"` or `"https"` | [1] |
-| `http.server_name` | The server name (not including port). This should be obtained via configuration. If no such configuration can be obtained, this attribute MUST NOT be set (a `host.name` attribute that is analogous to `peer.hostname` but for the host instead of the peer should be used instead). | [1] |
+| `http.server_name` | The server name (not including port). This should be obtained via configuration. If no such configuration can be obtained, this attribute MUST NOT be set ( `host.name` should be used instead). | [1] |
+| `host.name` |  Analogous to `peer.hostname` but for the host instead of the peer. | [1] |
 | `http.route` | The matched route (path template). E.g. `"/users/:userID?"`. | No |
 | `http.app` | An identifier for the whole HTTP application. E.g. Flask app name, `spring.application.name`, etc. | No |
 | `http.app_root` |The path prefix of the URL that identifies this `http.app`. Also known as "context root". If multiple roots exist, the one that was matched for this request should be used. | No |
 | `http.client_ip` | The IP address of the original client behind all proxies, if known (e.g. from [X-Forwarded-For][]). | No |
+| `host.port` | Local port. E.g., `80` (integer). Analogous to `peer.port`. | No |
 
 [HTTP request line]: https://tools.ietf.org/html/rfc7230#section-3.1.1
 [HTTP host header]: https://tools.ietf.org/html/rfc7230#section-5.4

--- a/specification/data-semantic-conventions.md
+++ b/specification/data-semantic-conventions.md
@@ -62,7 +62,7 @@ If the route cannot be determined, the `name` attribute MUST be set as defined i
 | `http.target` | The full request target as passed in a [HTTP request line][] or equivalent, e.g. `/path/12314/?q=ddds#123"`. | [1] |
 | `http.host` | The value of the [HTTP host header][]. Note that this might be empty or not present. | [1] |
 | `http.scheme` | The URI scheme identifying the used protocol: `"http"` or `"https"` | [1] |
-| `http.server_name` | The server name (not including port). This should be obtained via configuration. If no such configuration can be obtained, this attribute MUST NOT be set ( `host.name` should be used instead). | [1] |
+| `http.server_name` | The (primary) server name (usually not including a port). This should be obtained via configuration, e.g. the Apache [`ServerName`][ap-sn] directive or NGINX [server_name][nx-sn] . If no such configuration can be obtained, this attribute MUST NOT be set ( `host.name` should be used instead). | [1] |
 | `host.name` |  Analogous to `peer.hostname` but for the host instead of the peer. | [1] |
 | `http.route` | The matched route (path template). E.g. `"/users/:userID?"`. | No |
 | `http.app` | An identifier for the whole HTTP application. E.g. Flask app name, `spring.application.name`, etc. | No |
@@ -73,6 +73,8 @@ If the route cannot be determined, the `name` attribute MUST be set as defined i
 [HTTP request line]: https://tools.ietf.org/html/rfc7230#section-3.1.1
 [HTTP host header]: https://tools.ietf.org/html/rfc7230#section-5.4
 [X-Forwarded-For]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
+[ap-sn]: https://httpd.apache.org/docs/2.4/mod/core.html#servername
+[nx-xn]: http://nginx.org/en/docs/http/ngx_http_core_module.html#server_name
 
 **[1]**: `http.url` is usually not readily available on the server side but would have to be assembled in a cumbersome and sometimes lossy process from other information (see e.g. <https://github.com/open-telemetry/opentelemetry-python/pull/148>).
 It is thus preferred to supply the raw data that *is* available.


### PR DESCRIPTION
This PR aims to improve the semantic conventions for HTTP. For that, it also draws from experience at @Dynatrace. We plan to later (hopefully soon) make similar PRs for other semantic convention areas, including a clean-up of the `host.*` and `port.*` attributes used here.