### PR TITLE
 Add span watcher processor to SDK spec

### DIFF
--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -303,8 +303,7 @@ were first provided to the processor longer than this timeout ago are dropped fr
 list of watched spans and therefore updates will no longer be reported for them.
 This timeout, however, should only apply to this processor and MUST NOT affect spans
 that are ended properly after the timeout. If `exportEndedSpans` is set, the span MUST
-still be exported once ended. Other processors, including the simple and batching
-processor, will still export these spans as they normally would.
+still be exported once ended.
 
 
 ### Span Exporter

--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -277,7 +277,10 @@ have been started more than `reportIntervalMillis` ago, are exported as is.
 * `exporterTimeoutMillis` - how long the export can run before it is cancelled.
   The default value is `30000`.
 * `maxExportBatchSize` - the maximum batch size of every export. It must be
-  smaller or equal to `maxQueueSize`. The default value is `512`.
+  smaller or equal to `maxWatchedSpans`. The default value is `512`.
+* `exportEndedSpans` (boolean) - if set, spans are also exported once they are
+  ended.
+  The default value is `false`.
 * `spanDurationTimeoutMillis` - On each report interval, spans older than
   `spanDurationTimeoutMillis` which have not yet ended will be dropped from
   the watch list.

--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -265,14 +265,14 @@ high contention in a very high traffic service.
 This implementation passes spans that have been started but not yet ended
 to the configured exporter. These spans are called _unfinished_ spans.
 On each interval defined by `reportIntervalMillis`, all unfinished spans that
-have been started more than `reportIntervalMillis` ago, are exported.
+have been started at least `reportIntervalMillis` ago, are exported.
 
 **Configurable parameters:**
 
-* `exporter` - the exporter where the spans are pushed.
+* `exporter` - the exporter to which the spans are pushed.
 * `maxWatchedSpans` - the maximum number of unfinished spans to be watched.
   While reached, no new spans will be accepted. The default value is `2048`.
-* `reportIntervalMillis` - the delay interval in milliseconds between two
+* `reportIntervalMillis` - the mimimum delay interval in milliseconds between two
   consecutive exports. The default value is `5000`.
 * `exporterTimeoutMillis` - how long the export can run before it is cancelled.
   The default value is `30000`.
@@ -284,7 +284,7 @@ have been started more than `reportIntervalMillis` ago, are exported.
 * `spanDurationTimeoutMillis` - On each report interval, spans older than
   `spanDurationTimeoutMillis` which have not yet ended will be dropped from
   the watch list.
-  The default is `60000`.
+  The default is `60000` (1 minute).
   (_only applies to languages where weak references are not supported or
   suitable_)
 

--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -289,9 +289,10 @@ have been started at least `reportIntervalMillis` ago, are exported.
   suitable_)
 
 In order to avoid multiple exports potentially being blocked on connection issues or
-when `reportIntervalMillis` is set inappropriately, exports should *not* be performed
-in parallel. If a previous export is still in progress on the next
-`reportIntervalMillis`, the current export should be skipped.
+when `reportIntervalMillis` is set inappropriately, exports SHOULD generally *not*
+be performed in parallel.
+If an export would normally happen while another export by this SpanProcessor is
+still running, the export is skipped.
 
 For languages that support the concept of weak references it is recommended to
 only use these for keeping references to unfinished spans in the processor.

--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -281,8 +281,8 @@ have been started at least `reportIntervalMillis` ago, are exported.
 * `exportEndedSpans` (boolean) - if set, spans are also exported once they are
   ended.
   The default value is `true`.
-* `maxSpanDurationMillis` - On each report interval, spans older than
-  `maxSpanDurationMillis` which have not yet ended will be dropped from
+* `maxSpanAgeMillis` - On each report interval, spans older than
+  `maxSpanAgeMillis` which have not yet ended will be dropped from
   the watch list.
   The default is `60000` (1 minute).
   (_only applies to languages where weak references are not supported or
@@ -299,7 +299,7 @@ only use these for keeping references to unfinished spans in the processor.
 Otherwise, it would accumulate references to spans abandoned by the user without
 ending them and therefore potentially leak memory.
 If weak references are not supported or suitable to be used, the timeout parameter
-`maxSpanDurationMillis` should be added for this processor. Unfinished spans which
+`maxSpanAgeMillis` should be added for this processor. Unfinished spans which
 were first provided to the processor longer ago than this timeout are dropped from the
 list of watched spans and therefore updates will no longer be reported for them.
 This timeout, however, should only apply to this processor and MUST NOT affect spans

--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -264,35 +264,37 @@ high contention in a very high traffic service.
 
 This implementation passes spans that have been started but not yet ended
 to the configured exporter.
-On each interval defined by `reportIntervalMillis`, all unfinished spans that
+On each interval defined by `reportIntervalMillis`, all un-ended spans that
 have been started more than `reportIntervalMillis` ago, are exported as is.
 
 **Configurable parameters:**
 
 * `exporter` - the exporter where the spans are pushed.
-* `maxQueueSize` - the maximum queue size. After the size is reached spans are
-  dropped. The default value is `2048`.
+* `maxWatchedSpans` - the maximum number of un-ended spans to be watched.
+  While reached, no new spans will be accepted. The default value is `2048`.
 * `reportIntervalMillis` - the delay interval in milliseconds between two
   consecutive exports. The default value is `5000`.
 * `exporterTimeoutMillis` - how long the export can run before it is cancelled.
   The default value is `30000`.
 * `maxExportBatchSize` - the maximum batch size of every export. It must be
   smaller or equal to `maxQueueSize`. The default value is `512`.
+* `spanDurationTimeoutMillis` - On each report interval, spans older than
+  `spanDurationTimeoutMillis` which have not yet ended will be dropped.
+  The default is `???`.
+  (_only applies to languages where weak references are not supported or
+  suitable_)
 
 For languages that support the concept of weak references it is recommended to
-only use these for keeping references to unfinished spans in the processor.
+only use these for keeping references to un-ended spans in the processor.
 Otherwise, it would accumulate references to spans abandoned by the user without
 ending them and therefore potentially leak memory.
-If weak references are not supported, a timeout parameter should be added for
-this processor, after which unfinished spans are dropped without reporting
-further updates. This timeout, however, should only apply to this processor and
-MUST NOT affect spans that are ended properly after the timeout. Other
-processors, including the simple and batching processor, will still export
-these spans once finished.
+If weak references are not supported or suitable for this application, a timeout
+parameter should be added for this processor, after which un-ended spans are
+dropped without reporting further updates. This timeout, however, should only
+apply to this processor and MUST NOT affect spans that are ended properly after
+the timeout. Other processors, including the simple and batching processor, will
+still export these spans as they normally would.
 
-* `spanDurationTimeoutMillis` - no further updates are sent for spans that have
-  been started longer in the past than the specified timeout.
-  The default is `???`.
 
 ### Span Exporter
 

--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -280,7 +280,7 @@ have been started at least `reportIntervalMillis` ago, are exported.
   smaller or equal to `maxWatchedSpans`. The default value is `512`.
 * `exportEndedSpans` (boolean) - if set, spans are also exported once they are
   ended.
-  The default value is `false`.
+  The default value is `true`.
 * `maxSpanDurationMillis` - On each report interval, spans older than
   `maxSpanDurationMillis` which have not yet ended will be dropped from
   the watch list.

--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -300,7 +300,7 @@ Otherwise, it would accumulate references to spans abandoned by the user without
 ending them and therefore potentially leak memory.
 If weak references are not supported or suitable to be used, the timeout parameter
 `maxSpanDurationMillis` should be added for this processor. Unfinished spans which
-were first provided to the processor longer than this timeout ago are dropped from the
+were first provided to the processor longer ago than this timeout are dropped from the
 list of watched spans and therefore updates will no longer be reported for them.
 This timeout, however, should only apply to this processor and MUST NOT affect spans
 that are ended properly after the timeout. If `exportEndedSpans` is set, the span MUST

--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -281,8 +281,8 @@ have been started at least `reportIntervalMillis` ago, are exported.
 * `exportEndedSpans` (boolean) - if set, spans are also exported once they are
   ended.
   The default value is `false`.
-* `spanDurationTimeoutMillis` - On each report interval, spans older than
-  `spanDurationTimeoutMillis` which have not yet ended will be dropped from
+* `maxSpanDurationMillis` - On each report interval, spans older than
+  `maxSpanDurationMillis` which have not yet ended will be dropped from
   the watch list.
   The default is `60000` (1 minute).
   (_only applies to languages where weak references are not supported or
@@ -298,7 +298,7 @@ only use these for keeping references to unfinished spans in the processor.
 Otherwise, it would accumulate references to spans abandoned by the user without
 ending them and therefore potentially leak memory.
 If weak references are not supported or suitable to be used, the timeout parameter
-`spanDurationTimeoutMillis` should be added for this processor. Unfinished spans which
+`maxSpanDurationMillis` should be added for this processor. Unfinished spans which
 were first provided to the processor longer than this timeout ago are dropped from the
 list of watched spans and therefore updates will no longer be reported for them.
 This timeout, however, should only apply to this processor and MUST NOT affect spans

--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -263,14 +263,14 @@ high contention in a very high traffic service.
 ##### Span watcher processor
 
 This implementation passes spans that have been started but not yet ended
-to the configured exporter.
-On each interval defined by `reportIntervalMillis`, all un-ended spans that
+to the configured exporter. These spans are called _unfinished_ spans.
+On each interval defined by `reportIntervalMillis`, all unfinished spans that
 have been started more than `reportIntervalMillis` ago, are exported as is.
 
 **Configurable parameters:**
 
 * `exporter` - the exporter where the spans are pushed.
-* `maxWatchedSpans` - the maximum number of un-ended spans to be watched.
+* `maxWatchedSpans` - the maximum number of unfinished spans to be watched.
   While reached, no new spans will be accepted. The default value is `2048`.
 * `reportIntervalMillis` - the delay interval in milliseconds between two
   consecutive exports. The default value is `5000`.
@@ -294,11 +294,11 @@ in parallel. If a previous export is still in progress on the next
 `reportIntervalMillis`, the current export should be skipped.
 
 For languages that support the concept of weak references it is recommended to
-only use these for keeping references to un-ended spans in the processor.
+only use these for keeping references to unfinished spans in the processor.
 Otherwise, it would accumulate references to spans abandoned by the user without
 ending them and therefore potentially leak memory.
 If weak references are not supported or suitable to be used, the timeout parameter
-`spanDurationTimeoutMillis` should be added for this processor. Un-ended spans which
+`spanDurationTimeoutMillis` should be added for this processor. Unfinished spans which
 were first provided to the processor longer than this timeout ago are dropped from the
 list of watched spans and therefore updates will no longer be reported for them.
 This timeout, however, should only apply to this processor and MUST NOT affect spans

--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -265,7 +265,7 @@ high contention in a very high traffic service.
 This implementation passes spans that have been started but not yet ended
 to the configured exporter. These spans are called _unfinished_ spans.
 On each interval defined by `reportIntervalMillis`, all unfinished spans that
-have been started more than `reportIntervalMillis` ago, are exported as is.
+have been started more than `reportIntervalMillis` ago, are exported.
 
 **Configurable parameters:**
 

--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -279,8 +279,9 @@ have been started more than `reportIntervalMillis` ago, are exported as is.
 * `maxExportBatchSize` - the maximum batch size of every export. It must be
   smaller or equal to `maxQueueSize`. The default value is `512`.
 * `spanDurationTimeoutMillis` - On each report interval, spans older than
-  `spanDurationTimeoutMillis` which have not yet ended will be dropped.
-  The default is `???`.
+  `spanDurationTimeoutMillis` which have not yet ended will be dropped from
+  the watch list.
+  The default is `60000`.
   (_only applies to languages where weak references are not supported or
   suitable_)
 
@@ -288,12 +289,13 @@ For languages that support the concept of weak references it is recommended to
 only use these for keeping references to un-ended spans in the processor.
 Otherwise, it would accumulate references to spans abandoned by the user without
 ending them and therefore potentially leak memory.
-If weak references are not supported or suitable for this application, a timeout
-parameter should be added for this processor, after which un-ended spans are
-dropped without reporting further updates. This timeout, however, should only
-apply to this processor and MUST NOT affect spans that are ended properly after
-the timeout. Other processors, including the simple and batching processor, will
-still export these spans as they normally would.
+If weak references are not supported or suitable for this application, the timeout
+parameter `spanDurationTimeoutMillis` should be added for this processor. Un-ended
+spans older than this timeout are dropped from the list of watched spans and
+therefore updates will not be reported any longer for them.
+This timeout, however, should only apply to this processor and MUST NOT affect spans
+that are ended properly after the timeout. Other processors, including the simple and
+batching processor, will still export these spans as they normally would.
 
 
 ### Span Exporter

--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -288,6 +288,11 @@ have been started more than `reportIntervalMillis` ago, are exported as is.
   (_only applies to languages where weak references are not supported or
   suitable_)
 
+In order to avoid multiple exports potentially being blocked on connection issues or
+when `reportIntervalMillis` is set inappropriately, exports should *not* be performed
+in parallel. If a previous export is still in progress on the next
+`reportIntervalMillis`, the current export should be skipped.
+
 For languages that support the concept of weak references it is recommended to
 only use these for keeping references to un-ended spans in the processor.
 Otherwise, it would accumulate references to spans abandoned by the user without

--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -260,6 +260,40 @@ high contention in a very high traffic service.
 * `maxExportBatchSize` - the maximum batch size of every export. It must be
   smaller or equal to `maxQueueSize`. The default value is `512`.
 
+##### Span watcher processor
+
+This implementation passes spans that have been started but not yet ended
+to the configured exporter.
+On each interval defined by `reportIntervalMillis`, all unfinished spans that
+have been started more than `reportIntervalMillis` ago, are exported as is.
+
+**Configurable parameters:**
+
+* `exporter` - the exporter where the spans are pushed.
+* `maxQueueSize` - the maximum queue size. After the size is reached spans are
+  dropped. The default value is `2048`.
+* `reportIntervalMillis` - the delay interval in milliseconds between two
+  consecutive exports. The default value is `5000`.
+* `exporterTimeoutMillis` - how long the export can run before it is cancelled.
+  The default value is `30000`.
+* `maxExportBatchSize` - the maximum batch size of every export. It must be
+  smaller or equal to `maxQueueSize`. The default value is `512`.
+
+For languages that support the concept of weak references it is recommended to
+only use these for keeping references to unfinished spans in the processor.
+Otherwise, it would accumulate references to spans abandoned by the user without
+ending them and therefore potentially leak memory.
+If weak references are not supported, a timeout parameter should be added for
+this processor, after which unfinished spans are dropped without reporting
+further updates. This timeout, however, should only apply to this processor and
+MUST NOT affect spans that are ended properly after the timeout. Other
+processors, including the simple and batching processor, will still export
+these spans once finished.
+
+* `spanDurationTimeoutMillis` - no further updates are sent for spans that have
+  been started longer in the past than the specified timeout.
+  The default is `???`.
+
 ### Span Exporter
 
 `Span Exporter` defines the interface that protocol-specific exporters must

--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -297,13 +297,14 @@ For languages that support the concept of weak references it is recommended to
 only use these for keeping references to un-ended spans in the processor.
 Otherwise, it would accumulate references to spans abandoned by the user without
 ending them and therefore potentially leak memory.
-If weak references are not supported or suitable for this application, the timeout
-parameter `spanDurationTimeoutMillis` should be added for this processor. Un-ended
-spans older than this timeout are dropped from the list of watched spans and
-therefore updates will not be reported any longer for them.
+If weak references are not supported or suitable to be used, the timeout parameter
+`spanDurationTimeoutMillis` should be added for this processor. Un-ended spans which
+were first provided to the processor longer than this timeout ago are dropped from the
+list of watched spans and therefore updates will no longer be reported for them.
 This timeout, however, should only apply to this processor and MUST NOT affect spans
-that are ended properly after the timeout. Other processors, including the simple and
-batching processor, will still export these spans as they normally would.
+that are ended properly after the timeout. If `exportEndedSpans` is set, the span MUST
+still be exported once ended. Other processors, including the simple and batching
+processor, will still export these spans as they normally would.
 
 
 ### Span Exporter

--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -271,7 +271,10 @@ have been started at least `reportIntervalMillis` ago, are exported.
 
 * `exporter` - the exporter to which the spans are pushed.
 * `maxWatchedSpans` - the maximum number of unfinished spans to be watched.
-  While reached, no new spans will be accepted. The default value is `2048`.
+  While reached, no new unfinished spans will be accepted. The default value is `1024`.
+* `maxEndedSpans` - the maximum number of ended spans waiting to be exported.
+  While reached, no new spans ended will be accepted. The default value is `2048`.
+  Only applicable if `exportEndedSpans` is set to `true`.
 * `reportIntervalMillis` - the mimimum delay interval in milliseconds between two
   consecutive exports. The default value is `5000`.
 * `exporterTimeoutMillis` - how long the export can run before it is cancelled.
@@ -305,6 +308,9 @@ list of watched spans and therefore updates will no longer be reported for them.
 This timeout, however, should only apply to this processor and MUST NOT affect spans
 that are ended properly after the timeout. If `exportEndedSpans` is set, the span MUST
 still be exported once ended.
+
+It is up to the implementation to apply the limits `maxWatchedSpans` and
+`maxEndedSpans` to all spans combined or to maintain two separate counters.
 
 
 ### Span Exporter


### PR DESCRIPTION
The proposed processor uses the same parameters as the batching processor but I renamed `scheduledDelayMillis` to `reportIntervalMillis` since I find it more expressive. If we desire to stay consistent here, I'm fine to adapt the name using in the batching processor or just stick to `scheduledDelayMillis`.