### PR TITLE
Introduce semantic conventions for CloudEvents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ release.
   ([#1890](https://github.com/open-telemetry/opentelemetry-specification/pull/1890))
 - Add HTTP request and response headers semantic conventions.
   ([#1898](https://github.com/open-telemetry/opentelemetry-specification/pull/1898))
+- Add semantic conventions for [CloudEvents](https://cloudevents.io).
+  ([#???](https://github.com/open-telemetry/opentelemetry-specification/pull/???))
 
 ### Compatibility
 

--- a/semantic_conventions/trace/cloudevents.yaml
+++ b/semantic_conventions/trace/cloudevents.yaml
@@ -1,0 +1,40 @@
+groups:
+  - id: cloudevents
+    prefix: cloudevents
+    brief: >
+        This document defines attributes for CloudEvents.
+        CloudEvents is a specification on how to define event data in a standard way.
+        These attributes can be attached to spans when performing operations with CloudEvents, regardless of the protocol being used.
+    attributes:
+      - id: event_id
+        type: string
+        brief: >
+          The [event_id](https://github.com/cloudevents/spec/blob/master/spec.md#id) identifies the event within the scope of a producer.
+        examples: ['123e4567-e89b-12d3-a456-426614174000', 'producer-1']
+      - id: source
+        type: string
+        brief: >
+          The [source](https://github.com/cloudevents/spec/blob/master/spec.md#source-1) identifies the context in which an event happened.
+        examples: ['https://github.com/cloudevents', '/cloudevents/spec/pull/123', 'my-service' ]
+      - id: spec_version
+        type: string
+        brief: >
+          The [version of the CloudEvents specification](https://github.com/cloudevents/spec/blob/master/spec.md#specversion) which the event uses.
+        examples: '1.0'
+      - id: event_type
+        type: string
+        brief: >
+          The [event_type](https://github.com/cloudevents/spec/blob/master/spec.md#type) contains a value describing the type of event related to the originating occurrence.
+        examples: ['com.github.pull_request.opened', 'com.example.object.deleted.v2']
+      - id: data_content_type
+        type: string
+        brief: >
+          The [content type](https://github.com/cloudevents/spec/blob/master/spec.md#datacontenttype) of the event `data` value.
+        note: >
+          If present, MUST adhere to the format specified in [RFC 2046](https://datatracker.ietf.org/doc/html/rfc2046)
+        examples: 'application/json'
+      - id: subject
+        type: string
+        brief: >
+          The [subject](https://github.com/cloudevents/spec/blob/master/spec.md#subject) of the event in the context of the event producer (identified by source).
+        examples: 'mynewfile.jpg'

--- a/semantic_conventions/trace/cloudevents.yaml
+++ b/semantic_conventions/trace/cloudevents.yaml
@@ -26,13 +26,6 @@ groups:
         brief: >
           The [event_type](https://github.com/cloudevents/spec/blob/master/spec.md#type) contains a value describing the type of event related to the originating occurrence.
         examples: ['com.github.pull_request.opened', 'com.example.object.deleted.v2']
-      - id: data_content_type
-        type: string
-        brief: >
-          The [content type](https://github.com/cloudevents/spec/blob/master/spec.md#datacontenttype) of the event `data` value.
-        note: >
-          If present, MUST adhere to the format specified in [RFC 2046](https://datatracker.ietf.org/doc/html/rfc2046)
-        examples: 'application/json'
       - id: subject
         type: string
         brief: >

--- a/specification/trace/semantic_conventions/cloudevents.md
+++ b/specification/trace/semantic_conventions/cloudevents.md
@@ -2,7 +2,7 @@
 
 This document defines how to describe sending and receiving [CloudEvents](https://cloudevents.io/) with spans.
 
-The transport involved in sending/receiving CloudEvents is represented by a separated span, depending on the underlying protocol used.
+The transport involved in sending/receiving CloudEvents is represented by a separate span, depending on the underlying protocol used.
 
 **Status**: [Experimental](../../document-status.md)
 

--- a/specification/trace/semantic_conventions/cloudevents.md
+++ b/specification/trace/semantic_conventions/cloudevents.md
@@ -1,6 +1,6 @@
 # CloudEvents
 
-This document defines how to apply semantic conventions when instrumenting code that uses [CloudEvents](https://cloudevents.io/). 
+This document defines how to apply semantic conventions when instrumenting code that uses [CloudEvents](https://cloudevents.io/).
 These semantic conventions are general and not tied to any protocol used to send/receive the events.
 
 **Status**: [Experimental](../../document-status.md)

--- a/specification/trace/semantic_conventions/cloudevents.md
+++ b/specification/trace/semantic_conventions/cloudevents.md
@@ -1,0 +1,51 @@
+# CloudEvents
+
+This document defines how to apply semantic conventions when instrumenting code that uses [CloudEvents](https://cloudevents.io/). 
+These semantic conventions are general and not tied to any protocol used to send/receive the events.
+
+**Status**: [Experimental](../../document-status.md)
+
+<!-- Re-generate TOC with `markdown-toc --no-first-h1 -i` -->
+
+<!-- toc -->
+
+- [Span name](#span-name)
+- [Span kind](#span-kind)
+- [Attributes](#attributes)
+
+<!-- tocstop -->
+
+## Span name
+
+The span name SHOULD be set to the `cloudevents.` prefix, followed by the event type in the following format:
+
+```
+cloudevents.<event type name>
+```
+
+The event type name SHOULD only be used for the span name if it is known to be of low cardinality (cf. [general span name guidelines](../api.md#span)).
+
+Examples:
+
+* `cloudevents.com.github.pull_request.opened`
+
+## Span kind
+
+A producer of an event should set the span kind to `PRODUCER` unless it synchronously waits for a response: then it should use `CLIENT`.
+The processor of the message should set the kind to `CONSUMER`, unless it always sends back a reply that is directed to the producer of the event
+(as opposed to e.g., a queue on which the producer happens to listen): then it should use `SERVER`.
+
+## Attributes
+
+<!-- semconv cloudevents -->
+| Attribute  | Type | Description  | Examples  | Required |
+|---|---|---|---|---|
+| `cloudevents.event_id` | string | The [event_id](https://github.com/cloudevents/spec/blob/master/spec.md#id) identifies the event within the scope of a producer. | `123e4567-e89b-12d3-a456-426614174000`; `producer-1` | No |
+| `cloudevents.source` | string | The [source](https://github.com/cloudevents/spec/blob/master/spec.md#source-1) identifies the context in which an event happened. | `https://github.com/cloudevents`; `/cloudevents/spec/pull/123`; `my-service` | No |
+| `cloudevents.spec_version` | string | The [version of the CloudEvents specification](https://github.com/cloudevents/spec/blob/master/spec.md#specversion) which the event uses. | `1.0` | No |
+| `cloudevents.event_type` | string | The [event_type](https://github.com/cloudevents/spec/blob/master/spec.md#type) contains a value describing the type of event related to the originating occurrence. | `com.github.pull_request.opened`; `com.example.object.deleted.v2` | No |
+| `cloudevents.data_content_type` | string | The [content type](https://github.com/cloudevents/spec/blob/master/spec.md#datacontenttype) of the event `data` value. [1] | `application/json` | No |
+| `cloudevents.subject` | string | The [subject](https://github.com/cloudevents/spec/blob/master/spec.md#subject) of the event in the context of the event producer (identified by source). | `mynewfile.jpg` | No |
+
+**[1]:** If present, MUST adhere to the format specified in [RFC 2046](https://datatracker.ietf.org/doc/html/rfc2046)
+<!-- endsemconv -->

--- a/specification/trace/semantic_conventions/cloudevents.md
+++ b/specification/trace/semantic_conventions/cloudevents.md
@@ -1,7 +1,8 @@
 # CloudEvents
 
-This document defines how to apply semantic conventions when instrumenting code that uses [CloudEvents](https://cloudevents.io/).
-These semantic conventions are general and not tied to any protocol used to send/receive the events.
+This document defines how to describe sending and receiving [CloudEvents](https://cloudevents.io/) with spans.
+
+The transport involved in sending/receiving CloudEvents is represented by a separated span, depending on the underlying protocol used.
 
 **Status**: [Experimental](../../document-status.md)
 
@@ -17,23 +18,21 @@ These semantic conventions are general and not tied to any protocol used to send
 
 ## Span name
 
-The span name SHOULD be set to the `cloudevents.` prefix, followed by the event type in the following format:
+The span name should be a combination of the `CloudEvents` prefix, followed by the event type as in the following format:
 
 ```
-cloudevents.<event type name>
+CloudEvents <event_type>
 ```
 
-The event type name SHOULD only be used for the span name if it is known to be of low cardinality (cf. [general span name guidelines](../api.md#span)).
+The event type SHOULD only be used as part of the span name if it is known to be of low cardinality (cf. [general span name guidelines](../api.md#span)).
 
 Examples:
 
-* `cloudevents.com.github.pull_request.opened`
+* `CloudEvents com.github.pull_request.opened`
 
 ## Span kind
 
-A producer of an event should set the span kind to `PRODUCER` unless it synchronously waits for a response: then it should use `CLIENT`.
-The processor of the message should set the kind to `CONSUMER`, unless it always sends back a reply that is directed to the producer of the event
-(as opposed to e.g., a queue on which the producer happens to listen): then it should use `SERVER`.
+When an entity is acting as a sender of CloudEvents, it should set the span kind to `PRODUCER`. When acting as a receiver, it should set the span kind to `CONSUMER`.
 
 ## Attributes
 
@@ -44,8 +43,5 @@ The processor of the message should set the kind to `CONSUMER`, unless it always
 | `cloudevents.source` | string | The [source](https://github.com/cloudevents/spec/blob/master/spec.md#source-1) identifies the context in which an event happened. | `https://github.com/cloudevents`; `/cloudevents/spec/pull/123`; `my-service` | No |
 | `cloudevents.spec_version` | string | The [version of the CloudEvents specification](https://github.com/cloudevents/spec/blob/master/spec.md#specversion) which the event uses. | `1.0` | No |
 | `cloudevents.event_type` | string | The [event_type](https://github.com/cloudevents/spec/blob/master/spec.md#type) contains a value describing the type of event related to the originating occurrence. | `com.github.pull_request.opened`; `com.example.object.deleted.v2` | No |
-| `cloudevents.data_content_type` | string | The [content type](https://github.com/cloudevents/spec/blob/master/spec.md#datacontenttype) of the event `data` value. [1] | `application/json` | No |
 | `cloudevents.subject` | string | The [subject](https://github.com/cloudevents/spec/blob/master/spec.md#subject) of the event in the context of the event producer (identified by source). | `mynewfile.jpg` | No |
-
-**[1]:** If present, MUST adhere to the format specified in [RFC 2046](https://datatracker.ietf.org/doc/html/rfc2046)
 <!-- endsemconv -->


### PR DESCRIPTION
This PR is a "spin-off" of the [#1951](https://github.com/open-telemetry/opentelemetry-specification/pull/1951). 

After discussions both during the PR review and in the messaging SIG meeting, it was agreed that the suggested attributes make sense when instrumenting code that uses CloudEvents, but not in the scope of messaging systems as it was initially presented. 

I'm re-creating it but making it as a "standalone" new semantic convention file, exclusively for CloudEvents.
