### PR TITLE
Update CloudEvents spec based on meeting discussion

### DIFF
--- a/specification/trace/semantic_conventions/cloudevents.md
+++ b/specification/trace/semantic_conventions/cloudevents.md
@@ -42,7 +42,7 @@ When instrumented library supports processing of a single CloudEvent, instrument
 **Span name:** `CloudEvents Process <event_type>`
 **Span kind:** CONSUMER
 
-Note: CloudEvents processing does not follow a common pattern. Some libraries that work with CloudEvents expose handlers for processing (e.g.  [CloudEvents Go SDK](https://github.com/cloudevents/sdk-go#receive-your-first-cloudevent)) and are able to auto-instrument processing calls. In other cases, when library does not have CloudEvent handler or users choose not to use it, CloudEvents are deserialized or processed in application code. In this case, the instrumentation responsibility falls under the application owner.
+Note: CloudEvents processing does not follow a common pattern. Some "CloudEvents-enabled" libraries expose handlers for processing (e.g.  [CloudEvents Go SDK](https://github.com/cloudevents/sdk-go#receive-your-first-cloudevent)) and can auto-instrument the processing calls. Alternatively, a library might offer a handler, but the user chooses not to use it, or a library does not offer one at all. In such cases, the instrumentation responsibility falls under the application owner.
 
 ## Attributes
 

--- a/specification/trace/semantic_conventions/cloudevents.md
+++ b/specification/trace/semantic_conventions/cloudevents.md
@@ -14,10 +14,12 @@ Once the trace context is set on the event, it MUST not be modified.
 
 <!-- toc -->
 
-- [Spans](#spans)
-  * [Creation](#creation)
-  * [Processing](#processing)
-- [Attributes](#attributes)
+- [CloudEvents](#cloudevents)
+  - [Overview](#overview)
+  - [Spans](#spans)
+    - [Creation](#creation)
+    - [Processing](#processing)
+  - [Attributes](#attributes)
 
 <!-- tocstop -->
 
@@ -37,13 +39,12 @@ In case a CloudEvent is passed to the instrumented library with the Distributed 
 
 ### Processing
 
-To trace the processing of one or more CloudEvents, instrumentation SHOULD create a new span.
-If a single event is processed, instrumentation SHOULD use the remote trace context from the Distributed Tracing Extension as a parent or MAY instead add it as a link on the processing span.
-
-If multiple events are processed together, for each event being processed, if the event has the Distributed Tracing Extension populated, instrumentation MUST add a link to the trace context from the extension on the processing span.
+When instrumented library supports processing of a single CloudEvent, instrumentation SHOULD create a new span to trace it. Instrumentation SHOULD set the remote trace context from the Distributed Tracing Extension as a link on the processing span.
 
 **Span name:** `CloudEvents Process <event_type>`
 **Span kind:** CONSUMER
+
+Note: CloudEvents processing does not follow a common pattern. Some CloudEvents-enabled libraries expose handlers for CloudEvents processing (e.g.  [CloudEvents Go SDK](https://github.com/cloudevents/sdk-go#receive-your-first-cloudevent)) and are able to instrument processing calls. In other cases CloudEvents are deserialized or processed in application code and then application is responsible for instrumentation.
 
 ## Attributes
 

--- a/specification/trace/semantic_conventions/cloudevents.md
+++ b/specification/trace/semantic_conventions/cloudevents.md
@@ -14,12 +14,10 @@ Once the trace context is set on the event, it MUST not be modified.
 
 <!-- toc -->
 
-- [CloudEvents](#cloudevents)
-  - [Overview](#overview)
-  - [Spans](#spans)
-    - [Creation](#creation)
-    - [Processing](#processing)
-  - [Attributes](#attributes)
+- [Spans](#spans)
+  * [Creation](#creation)
+  * [Processing](#processing)
+- [Attributes](#attributes)
 
 <!-- tocstop -->
 
@@ -44,7 +42,7 @@ When instrumented library supports processing of a single CloudEvent, instrument
 **Span name:** `CloudEvents Process <event_type>`
 **Span kind:** CONSUMER
 
-Note: CloudEvents processing does not follow a common pattern. Some CloudEvents-enabled libraries expose handlers for CloudEvents processing (e.g.  [CloudEvents Go SDK](https://github.com/cloudevents/sdk-go#receive-your-first-cloudevent)) and are able to instrument processing calls. In other cases CloudEvents are deserialized or processed in application code and then application is responsible for instrumentation.
+Note: CloudEvents processing does not follow a common pattern. Some libraries that work with CloudEvents expose handlers for processing (e.g.  [CloudEvents Go SDK](https://github.com/cloudevents/sdk-go#receive-your-first-cloudevent)) and are able to auto-instrument processing calls. In other cases, when library does not have CloudEvent handler or users choose not to use it, CloudEvents are deserialized or processed in application code. In this case, the instrumentation responsibility falls under the application owner.
 
 ## Attributes
 


### PR DESCRIPTION
- No batching on processing. Should we still come up with anything for this case? 
- Always populate link on the CONSUMER span, this way ambient context becomes a parent of CloudEvent processing - it brings consistency 
- Add note on multiple cloudevents processing patterns
/cc @joaopgrassi 