### PR TITLE
Add partial success response guidance

### DIFF
--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -155,12 +155,18 @@ the specific message to use in the [Success](#success),
 ##### Success
 
 The success response indicates telemetry data is successfully processed by the
-server. If the server receives an empty request (a request that does not carry
+server.
+
+The success response may also be used when telemetry data processing is done
+at a later point by the server. In such cases, the server may want to return
+immediately in order to keep a low-latency communication with clients.
+
+If the server receives an empty request (a request that does not carry
 any telemetry data) the server SHOULD respond with success.
 
-On success, the server response MUST be
-a Protobuf-encoded [Export*ServiceResponse](https://github.com/open-telemetry/opentelemetry-proto) message
-(`ExportTraceServiceResponse` for traces,
+On success, the server response MUST be a Protobuf-encoded
+[Export*ServiceResponse](https://github.com/open-telemetry/opentelemetry-proto)
+message (`ExportTraceServiceResponse` for traces,
 `ExportMetricsServiceResponse` for metrics and
 `ExportLogsServiceResponse` for logs).
 
@@ -174,9 +180,9 @@ in case of a successful response.
 
 If the processing of the request is partially successful
 (i.e. when the server accepts only parts of the data and rejects the rest), the
-server response MUST be a
-Protobuf-encoded [Export*ServiceResponse](https://github.com/open-telemetry/opentelemetry-proto) message
-(`ExportTraceServiceResponse` for traces,
+server response MUST be a Protobuf-encoded
+[Export*ServiceResponse](https://github.com/open-telemetry/opentelemetry-proto)
+message (`ExportTraceServiceResponse` for traces,
 `ExportMetricsServiceResponse` for metrics and
 `ExportLogsServiceResponse` for logs).
 
@@ -188,9 +194,10 @@ Additionally, the server MUST initialize the `partial_success` field
 the number of spans/data points/log records it accepted.
 
 The server MAY populate the `error_message` field with a human-readable
-error message in English. The protocol does not attempt to define the content
-nor structure of such error message, but it should generally offer guidance
-on how users can address the issues.
+error message in English. The message should generally explain why the
+server rejected parts of the data, and should offer guidance on how users
+can address the issues. The protocol does not attempt to define the content
+or structure of such error message.
 
 The client MUST NOT retry the request when it receives a partial success
 response where the `partial_success` is populated.
@@ -440,7 +447,13 @@ header.
 ##### Success
 
 The success response indicates telemetry data is successfully processed by the
-server. If the server receives an empty request (a request that does not carry
+server.
+
+The success response may also be used when telemetry data processing is done
+at a later point by the server. In such cases, the server may want to return
+immediately in order to keep a low-latency communication with clients.
+
+If the server receives an empty request (a request that does not carry
 any telemetry data) the server SHOULD respond with success.
 
 On success, the server MUST respond with `HTTP 200 OK`. The response body MUST be
@@ -473,9 +486,10 @@ Additionally, the server MUST initialize the `partial_success` field
 the number of spans/data points/log records it accepted.
 
 The server MAY populate the `error_message` field with a human-readable
-error message in English. The protocol does not attempt to define the content
-nor structure of such error message, but it should generally offer guidance
-on how users can address the issues.
+error message in English. The message should generally explain why the
+server rejected parts of the data, and should offer guidance on how users
+can address the issues. The protocol does not attempt to define the content
+or structure of such error message.
 
 The client MUST NOT retry the request when it receives a partial success
 response where the `partial_success` is populated.

--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -168,13 +168,17 @@ The server SHOULD respond with success no sooner than after successfully
 decoding and validating the request.
 
 The server MUST leave the `partial_success` field unset
-in case of a successfull response.
+in case of a successful response.
 
 ##### Partial Success
 
-If the processing of the request is partially successfull
-(i.e. when the server accepts only parts of the data and rejects the rest) the
-server MUST respond with the same message types as specified on the Success case.
+If the processing of the request is partially successful
+(i.e. when the server accepts only parts of the data and rejects the rest), the
+server response MUST be a
+Protobuf-encoded [Export*ServiceResponse](https://github.com/open-telemetry/opentelemetry-proto) message
+(`ExportTraceServiceResponse` for traces,
+`ExportMetricsServiceResponse` for metrics and
+`ExportLogsServiceResponse` for logs).
 
 Additionally, the server MUST initialize the `partial_success` field
 (`ExportTracePartialSuccess` message for traces,
@@ -185,7 +189,7 @@ the number of spans/data points/log records it accepted.
 
 The server MAY populate the `error_message` field with a human-readable
 error message in English. The protocol does not attempt to define the content
-nor structure of such error message, but it SHOULD generally offer guidance
+nor structure of such error message, but it should generally offer guidance
 on how users can address the issues.
 
 ##### Failures
@@ -446,14 +450,17 @@ The server SHOULD respond with success no sooner than after successfully
 decoding and validating the request.
 
 The server MUST leave the `partial_success` field unset
-in case of a successfull response.
+in case of a successful response.
 
 ##### Partial Success
 
-If the processing of the request is partially successfull
-(i.e. when the server accepts only parts of the data and rejects the rest) the
-server MUST respond with the same message types and HTTP status code as
-specified on the Success case.
+If the processing of the request is partially successful
+(i.e. when the server accepts only parts of the data and rejects the rest), the
+server MUST respond with `HTTP 200 OK`. The response body MUST be
+a Protobuf-encoded [Export*ServiceResponse](https://github.com/open-telemetry/opentelemetry-proto)
+message (`ExportTraceServiceResponse` for traces,
+`ExportMetricsServiceResponse` for metrics and
+`ExportLogsServiceResponse` for logs).
 
 Additionally, the server MUST initialize the `partial_success` field
 (`ExportTracePartialSuccess` message for traces,
@@ -464,7 +471,7 @@ the number of spans/data points/log records it accepted.
 
 The server MAY populate the `error_message` field with a human-readable
 error message in English. The protocol does not attempt to define the content
-nor structure of such error message, but it SHOULD generally offer guidance
+nor structure of such error message, but it should generally offer guidance
 on how users can address the issues.
 
 ##### Failures

--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -39,6 +39,7 @@ nodes such as collectors and telemetry backends.
 - [Known Limitations](#known-limitations)
   * [Request Acknowledgements](#request-acknowledgements)
     + [Duplicate Data](#duplicate-data)
+    + [Partial success retry](#partial-success-retry)
 - [Future Versions and Interoperability](#future-versions-and-interoperability)
 - [Glossary](#glossary)
 - [References](#references)

--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -158,10 +158,11 @@ The success response indicates telemetry data is successfully processed by the
 server. If the server receives an empty request (a request that does not carry
 any telemetry data) the server SHOULD respond with success.
 
-Success response is returned via
-[Export*ServiceResponse](https://github.com/open-telemetry/opentelemetry-proto)
-message (`ExportTraceServiceResponse` for traces, `ExportMetricsServiceResponse`
-for metrics, `ExportLogsServiceResponse` for logs).
+On success, the server response MUST be
+a Protobuf-encoded [Export*ServiceResponse](https://github.com/open-telemetry/opentelemetry-proto) message
+(`ExportTraceServiceResponse` for traces,
+`ExportMetricsServiceResponse` for metrics and
+`ExportLogsServiceResponse` for logs).
 
 The server SHOULD respond with success no sooner than after successfully
 decoding and validating the request.
@@ -184,8 +185,8 @@ the number of spans/data points/log records it accepted.
 
 The server MAY populate the `error_message` field with a human-readable
 error message in English. The protocol does not attempt to define the content
-of such error message, but it SHOULD generally offer guidance in how senders
-can address the issues.
+nor structure of such error message, but it SHOULD generally offer guidance
+on how users can address the issues.
 
 ##### Failures
 
@@ -435,10 +436,11 @@ The success response indicates telemetry data is successfully processed by the
 server. If the server receives an empty request (a request that does not carry
 any telemetry data) the server SHOULD respond with success.
 
-On success the server MUST respond with `HTTP 200 OK`. Response body MUST be
-a Protobuf-encoded `ExportTraceServiceResponse` message for traces,
-`ExportMetricsServiceResponse` message for metrics and
-`ExportLogsServiceResponse` message for logs.
+On success, the server MUST respond with `HTTP 200 OK`. The response body MUST be
+a Protobuf-encoded [Export*ServiceResponse](https://github.com/open-telemetry/opentelemetry-proto)
+message (`ExportTraceServiceResponse` for traces,
+`ExportMetricsServiceResponse` for metrics and
+`ExportLogsServiceResponse` for logs).
 
 The server SHOULD respond with success no sooner than after successfully
 decoding and validating the request.

--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -158,8 +158,8 @@ The success response indicates telemetry data is successfully processed by the
 server.
 
 The success response may also be used when telemetry data processing is done
-at a later point by the server. In such cases, the server may want to return
-immediately in order to keep a low-latency communication with clients.
+at a later point. In such cases, the server may want to return
+immediately to ensure low-latency communication with clients.
 
 If the server receives an empty request (a request that does not carry
 any telemetry data) the server SHOULD respond with success.
@@ -194,10 +194,10 @@ Additionally, the server MUST initialize the `partial_success` field
 the number of spans/data points/log records it accepted.
 
 The server MAY populate the `error_message` field with a human-readable
-error message in English. The message should generally explain why the
+error message in English. The message should explain why the
 server rejected parts of the data, and should offer guidance on how users
-can address the issues. The protocol does not attempt to define the content
-or structure of such error message.
+can address the issues.
+The protocol does not attempt to define the structure of such an error message.
 
 The client MUST NOT retry the request when it receives a partial success
 response where the `partial_success` is populated.
@@ -450,8 +450,8 @@ The success response indicates telemetry data is successfully processed by the
 server.
 
 The success response may also be used when telemetry data processing is done
-at a later point by the server. In such cases, the server may want to return
-immediately in order to keep a low-latency communication with clients.
+at a later point. In such cases, the server may want to return
+immediately to ensure low-latency communication with clients.
 
 If the server receives an empty request (a request that does not carry
 any telemetry data) the server SHOULD respond with success.
@@ -486,10 +486,10 @@ Additionally, the server MUST initialize the `partial_success` field
 the number of spans/data points/log records it accepted.
 
 The server MAY populate the `error_message` field with a human-readable
-error message in English. The message should generally explain why the
+error message in English. The message should explain why the
 server rejected parts of the data, and should offer guidance on how users
-can address the issues. The protocol does not attempt to define the content
-or structure of such error message.
+can address the issues.
+The protocol does not attempt to define the structure of such an error message.
 
 The client MUST NOT retry the request when it receives a partial success
 response where the `partial_success` is populated.
@@ -617,10 +617,10 @@ OTLP request (e.g. quota exceeded,
 data not conforming with the server's standards, etc).
 
 The protocol offers a basic way of communicating partial reception success
-from the server to the client. Such partial success information contains 
+from the server to the client. Such partial success information contains
 how many spans/data points/log records were accepted and a general error
 message. With only such information it is not feasible to achieve any type
-of automatic retry by clients. 
+of automatic retry by clients.
 
 The protocol does not give guidance on how such partial success requests can be
 retried by clients. Attempting to do so would complicate the protocol and

--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -196,9 +196,9 @@ the number of spans/data points/log records it accepted.
 
 The server MAY populate the `error_message` field with a human-readable
 error message in English. The message should explain why the
-server rejected parts of the data, and should offer guidance on how users
+server rejected parts of the data, and might offer guidance on how users
 can address the issues.
-The protocol does not attempt to define the structure of such an error message.
+The protocol does not attempt to define the structure of the error message.
 
 The client MUST NOT retry the request when it receives a partial success
 response where the `partial_success` is populated.
@@ -488,9 +488,9 @@ the number of spans/data points/log records it accepted.
 
 The server MAY populate the `error_message` field with a human-readable
 error message in English. The message should explain why the
-server rejected parts of the data, and should offer guidance on how users
+server rejected parts of the data, and might offer guidance on how users
 can address the issues.
-The protocol does not attempt to define the structure of such an error message.
+The protocol does not attempt to define the structure of the error message.
 
 The client MUST NOT retry the request when it receives a partial success
 response where the `partial_success` is populated.
@@ -613,7 +613,7 @@ deliberate choice and is considered to be the right tradeoff for telemetry data.
 #### Partial success retry
 
 Each server has its particularities and its way of treating data. There
-could be many reasons why a given server only accepted parts of a
+can be many reasons why a given server only accepted parts of a
 OTLP request (e.g. quota exceeded,
 data not conforming with the server's standards, etc).
 

--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -192,6 +192,9 @@ error message in English. The protocol does not attempt to define the content
 nor structure of such error message, but it should generally offer guidance
 on how users can address the issues.
 
+The client MUST NOT retry the request when it receives a partial success
+response where the `partial_success` is populated.
+
 ##### Failures
 
 When an error is returned by the server it falls into 2 broad categories:
@@ -474,6 +477,9 @@ error message in English. The protocol does not attempt to define the content
 nor structure of such error message, but it should generally offer guidance
 on how users can address the issues.
 
+The client MUST NOT retry the request when it receives a partial success
+response where the `partial_success` is populated.
+
 ##### Failures
 
 If the processing of the request fails the server MUST respond with appropriate
@@ -588,6 +594,23 @@ no way of knowing if recently sent data was delivered if no acknowledgement was
 received yet. The client will typically choose to re-send such data to guarantee
 delivery, which may result in duplicate data on the server side. This is a
 deliberate choice and is considered to be the right tradeoff for telemetry data.
+
+#### Partial success retry
+
+Each server has its particularities and its way of treating data. There
+could be many reasons why a given server only accepted parts of a
+OTLP request (e.g. quota exceeded,
+data not conforming with the server's standards, etc).
+
+The protocol offers a basic way of communicating partial reception success
+from the server to the client. Such partial success information contains 
+how many spans/data points/log records were accepted and a general error
+message. With only such information it is not feasible to achieve any type
+of automatic retry by clients. 
+
+The protocol does not give guidance on how such partial success requests can be
+retried by clients. Attempting to do so would complicate the protocol and
+implementations significantly and is left out as a possible future area of work.
 
 ## Future Versions and Interoperability
 

--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -148,7 +148,7 @@ was not delivered.
 
 #### OTLP/gRPC Response
 
-Response MUST be the appropriate serialized Protobuf message (see below for
+The response MUST be the appropriate serialized Protobuf message (see below for
 the specific message to use in the [Success](#success),
 [Partial Success](#partial-success) and [Failure](#failures) cases).
 
@@ -416,7 +416,7 @@ numbers or strings are accepted when decoding.
 
 #### OTLP/HTTP Response
 
-Response body MUST be the appropriate serialized Protobuf message (see below for
+The response body MUST be the appropriate serialized Protobuf message (see below for
 the specific message to use in the [Success](#success-1),
 [Partial Success](#partial-success-1) and [Failure](#failures-1) cases).
 


### PR DESCRIPTION
After the protocols change is merged, we need to update the spec to instruct people on how to use it. 

This PR is a first attempt in trying to achieve it. I also refactored the gRPC response section to be more aligned with the HTTP one and vice-versa. They were not consistent with each other and now they are. 