### PR TITLE
Make context propagation requirements explict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ release.
   ([#2675](https://github.com/open-telemetry/opentelemetry-specification/pull/2675))
 - Add OpenSearch to db.system semantic conventions
   ([#2718](https://github.com/open-telemetry/opentelemetry-specification/pull/2718)).
+- Make context propagation requirements explict for messaging semantic conventions
+  ([#xyz](https://github.com/open-telemetry/opentelemetry-specification/pull/xyz)).
 
 ### Compatibility
 

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -87,9 +87,9 @@ when it is propagated from the producer to the consumer(s). To be able to correl
 consumer traces with producer traces using the existing context propagation mechanisms,
 all components must propagate context down the chain.
 
-This imposes a difficulty because it cannot be assumed, and in many cases,
-it is not even desired, that all components and layers to be instrumented and
-propagate context according to OpenTelemetry requirements.
+This imposes a requirement that all components are instrumented
+and propagate context according to OpenTelemetry requirements. In reality,
+this cannot be assumed, and in many cases is not even desired or possible.
 
 To be able to correlate consumer traces with producer traces without requiring
 intermediary instrumentation, the context needs to be propagated on a
@@ -107,20 +107,19 @@ to the consumer(s). Producer and consumer applications should be instrumented
 in a way so that the creation context is attached to messages and extracted
 from messages in a coordinated way.
 
-If the message creation context cannot be attached to the message and propagated,
-consumer traces cannot be directly correlated to producer traces.
+Consumer traces cannot be directly correlated to producer traces if the message
+creation context cannot be attached and propagated with the message.
 
 A producer SHOULD attach a message creation context to each message.
 The message creation context SHOULD be attached in such a way that it is
 not possible to be changed by intermediaries.
 
 > This document does not specify the exact mechanisms on how the creation context
-is attached/extracted to/from messages. Future versions of these conventions
-will give clear recommendations, following industry standards including, but not limited to
-(but not limited to)
-[Trace Context: AMQP protocol](https://w3c.github.io/trace-context-amqp/) and
-[Trace Context: MQTT protocol](https://w3c.github.io/trace-context-mqtt/)
-once those standards reach a stable state.
+> is attached/extracted to/from messages. Future versions of these conventions
+> will give clear recommendations, following industry standards including, but not limited to
+> [Trace Context: AMQP protocol](https://w3c.github.io/trace-context-amqp/) and
+> [Trace Context: MQTT protocol](https://w3c.github.io/trace-context-mqtt/)
+> once those standards reach a stable state.
 
 ### Span name
 

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -80,6 +80,38 @@ Often such destinations are unnamed or have an auto-generated name.
 
 Given these definitions, the remainder of this section describes the semantic conventions for Spans describing interactions with messaging systems.
 
+### Context propagation
+
+A message may pass many different components and layers in one or more intermediaries
+when it is propagated from the producer to the consumer. It cannot be assumed,
+and in many cases, it is not even desired, that all those components and layers
+are instrumented and propagate context according to OpenTelemetry requirements.
+
+A message creation context allows correlating the producer with the consumer(s)
+of a message, regardless of intermediary instrumentation. The message creation
+context is created by the producer and should be propagated to the consumer(s).
+This context helps to model the dependencies between producers and consumers,
+regardless of the underlying messaging transport mechanism and its instrumentation.
+
+Producer and consumer applications should be instrumented in a way so that
+the creation context is attached to messages and extracted from messages
+in a coordinated way.
+
+If the message creation context cannot be attached to the message and propagated,
+consumer traces cannot be directly correlated to producer traces.
+
+A producer SHOULD attach a message creation context to each message.
+The message creation context SHOULD be attached in a way so that it is
+not possible to be changed by intermediaries.
+
+> This document does not specify the exact mechanisms on how the creation context
+is attached/extracted to/from messages. Future versions of these conventions
+will give clear recommendations, following industry standards such as
+(but not limited to)
+[Trace Context: AMQP protocol](https://w3c.github.io/trace-context-amqp/) and
+[Trace Context: MQTT protocol](https://w3c.github.io/trace-context-mqtt/)
+once those standards reach a stable state.
+
 ### Span name
 
 The span name SHOULD be set to the message destination name and the operation being performed in the following format:

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -104,12 +104,10 @@ of a message and model the dependencies between them,
 regardless of the underlying messaging transport mechanism and its instrumentation.
 
 The message creation context is created by the producer and should be propagated
-to the consumer(s). Producer and consumer applications should be instrumented
-in a way so that the creation context is attached to messages and extracted
-from messages in a coordinated way.
+to the consumer(s).
 
 Consumer traces cannot be directly correlated to producer traces if the message
-creation context cannot be attached and propagated with the message.
+creation context is not attached and propagated with the message.
 
 A producer SHOULD attach a message creation context to each message.
 The message creation context SHOULD be attached in such a way that it is

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -83,19 +83,29 @@ Given these definitions, the remainder of this section describes the semantic co
 ### Context propagation
 
 A message may pass many different components and layers in one or more intermediaries
-when it is propagated from the producer to the consumer. It cannot be assumed,
-and in many cases, it is not even desired, that all those components and layers
-are instrumented and propagate context according to OpenTelemetry requirements.
+when it is propagated from the producer to the consumer(s). To be able to correlate
+consumer traces with producer traces using the existing context propagation mechanisms,
+all components must propagate context down the chain.
 
-A message creation context allows correlating the producer with the consumer(s)
-of a message, regardless of intermediary instrumentation. The message creation
-context is created by the producer and should be propagated to the consumer(s).
-This context helps to model the dependencies between producers and consumers,
+This imposes a difficulty because it cannot be assumed, and in many cases,
+it is not even desired, that all components and layers to be instrumented and
+propagate context according to OpenTelemetry requirements.
+
+To be able to correlate consumer traces with producer traces without requiring
+intermediary instrumentation, the context needs to be propagated on a
+*per-message* basis instead of on a *per-request* basis. This allows all components
+to have access to the same per-message context information, making it possible
+to correlate all the stages involved in processing a message with the message's
+creation.
+
+A message *creation context* allows correlating producer with consumer(s)
+of a message and model the dependencies between them,
 regardless of the underlying messaging transport mechanism and its instrumentation.
 
-Producer and consumer applications should be instrumented in a way so that
-the creation context is attached to messages and extracted from messages
-in a coordinated way.
+The message creation context is created by the producer and should be propagated
+to the consumer(s). Producer and consumer applications should be instrumented
+in a way so that the creation context is attached to messages and extracted
+from messages in a coordinated way.
 
 If the message creation context cannot be attached to the message and propagated,
 consumer traces cannot be directly correlated to producer traces.

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -88,9 +88,10 @@ when it is propagated from the producer to the consumer(s). To be able to correl
 consumer traces with producer traces using the existing context propagation mechanisms,
 all components must propagate context down the chain.
 
-This imposes a requirement that all components are instrumented
-and propagate context according to OpenTelemetry requirements. In reality,
-this cannot be assumed, and in many cases is not even desired or possible.
+Due to the complex nature of messaging systems, it cannot be assumed
+that all components are instrumented and propagate context accordingly.
+For example, an application using a messaging system offered via
+software as a service (SaaS) that does not propagate context will lead to incomplete traces.
 
 To be able to correlate consumer traces with producer traces without requiring
 intermediary instrumentation, the context needs to be propagated on a

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -82,7 +82,7 @@ Given these definitions, the remainder of this section describes the semantic co
 
 ### Context propagation
 
-A message may pass many different components and layers in one or more intermediaries
+A message may traverse many different components and layers in one or more intermediaries
 when it is propagated from the producer to the consumer(s). To be able to correlate
 consumer traces with producer traces using the existing context propagation mechanisms,
 all components must propagate context down the chain.
@@ -95,10 +95,10 @@ To be able to correlate consumer traces with producer traces without requiring
 intermediary instrumentation, the context needs to be propagated on a
 *per-message* basis instead of on a *per-request* basis. This allows all components
 to have access to the same per-message context information, making it possible
-to correlate all the stages involved in processing a message with the message's
+to correlate all stages involved in processing a message with the message's
 creation.
 
-A message *creation context* allows correlating producer with consumer(s)
+A message *creation context* allows correlating producers with consumers
 of a message and model the dependencies between them,
 regardless of the underlying messaging transport mechanism and its instrumentation.
 
@@ -111,12 +111,12 @@ If the message creation context cannot be attached to the message and propagated
 consumer traces cannot be directly correlated to producer traces.
 
 A producer SHOULD attach a message creation context to each message.
-The message creation context SHOULD be attached in a way so that it is
+The message creation context SHOULD be attached in such a way that it is
 not possible to be changed by intermediaries.
 
 > This document does not specify the exact mechanisms on how the creation context
 is attached/extracted to/from messages. Future versions of these conventions
-will give clear recommendations, following industry standards such as
+will give clear recommendations, following industry standards including, but not limited to
 (but not limited to)
 [Trace Context: AMQP protocol](https://w3c.github.io/trace-context-amqp/) and
 [Trace Context: MQTT protocol](https://w3c.github.io/trace-context-mqtt/)

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -12,6 +12,7 @@
   * [Conversations](#conversations)
   * [Temporary destinations](#temporary-destinations)
 - [Conventions](#conventions)
+  * [Context propagation](#context-propagation)
   * [Span name](#span-name)
   * [Span kind](#span-kind)
   * [Operation names](#operation-names)


### PR DESCRIPTION
This PR is an initial attempt in bring the contents from [OTEP 0205](https://github.com/open-telemetry/oteps/blob/main/text/trace/0205-messaging-semantic-conventions-context-propagation.md) into the existing messaging semantic conventions. 

As stated in the OTEP, the existing messaging semantic conventions rely on context to be propagated via the message but this requirement is implicit and not clearly stated in the conventions today.

The OTEP's and this PR intention is to make this requirement explicit in the current conventions, without introducing breaking changes or new behavior.
